### PR TITLE
fix: audit nitpicks - bugs, security, type safety, race conditions

### DIFF
--- a/src/main/dialog.ts
+++ b/src/main/dialog.ts
@@ -1,13 +1,20 @@
-import { app, dialog as electronDialog } from 'electron';
+import { app, dialog as electronDialog, MessageBoxReturnValue } from 'electron';
 import path from 'path';
 import { debugInfo, is } from './util';
 
-const validButtonIndex = (result: any) =>
-	result?.response && typeof result.response === 'number'
+const validButtonIndex = (result: MessageBoxReturnValue | number) =>
+	typeof result === 'object' && typeof result.response === 'number'
 		? result.response
-		: result;
+		: (result as number);
 
-const showAboutWindow = (options: any = {}) => {
+interface AboutWindowOptions {
+	icon?: string;
+	copyright?: string;
+	text?: string;
+	website?: string;
+}
+
+const showAboutWindow = (options: AboutWindowOptions = {}) => {
 	// TODO: When https://github.com/electron/electron/issues/18918 is fixed,
 	// these defaults should not need to be set for Linux.
 	// TODO: The defaults are standardized here, instead of being set in
@@ -16,7 +23,7 @@ const showAboutWindow = (options: any = {}) => {
 	const appName = app.getName();
 	const appVersion = app.getVersion();
 
-	const aboutPanelOptions: any = {
+	const aboutPanelOptions: Electron.AboutPanelOptionsOptions = {
 		applicationName: appName,
 		applicationVersion: appVersion,
 	};
@@ -25,14 +32,10 @@ const showAboutWindow = (options: any = {}) => {
 		aboutPanelOptions.iconPath = options.icon;
 	}
 
-	if (options.copyright) {
-		aboutPanelOptions.copyright = options.copyright;
-	}
-
-	if (options.text) {
-		aboutPanelOptions.copyright = `${options.copyright || ''}\n\n${
-			options.text
-		}`;
+	if (options.copyright || options.text) {
+		aboutPanelOptions.copyright = [options.copyright, options.text]
+			.filter(Boolean)
+			.join('\n\n');
 	}
 
 	if (options.website) {

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -91,7 +91,7 @@ export default class MenuBuilder {
 				label: 'Quit on Close',
 				type: 'checkbox',
 				id: 'quitOnWindowClose',
-				checked: getSetting('quitOnWindowClose'),
+				checked: getSetting('quitOnWindowClose') as boolean,
 				click: () => {
 					setSettings({
 						quitOnWindowClose: !getSetting('quitOnWindowClose'),

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -49,11 +49,16 @@ const electronHandler = {
 				ipcRenderer.removeListener(channel, subscription);
 			};
 		},
-		once(channel: string, func: (...args: unknown[]) => void) {
+		once(channel: string, func: (...args: unknown[]) => void): (() => void) | undefined {
 			if (!channels.includes(channel)) {
-				return;
+				return undefined;
 			}
-			ipcRenderer.once(channel, (_event, ...args) => func(...args));
+			const subscription = (_event: IpcRendererEvent, ...args: unknown[]) =>
+				func(...args);
+			ipcRenderer.once(channel, subscription);
+			return () => {
+				ipcRenderer.removeListener(channel, subscription);
+			};
 		},
 		removeAllListeners(channel: string) {
 			ipcRenderer.removeAllListeners(channel);

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -32,11 +32,18 @@ const initialize = () => {
 	}
 
 	// By default, we serve files from the assets folder
-	protocol.handle(PROTOCOL, (request: any) => {
-		// list all files in the directory
+	protocol.handle(PROTOCOL, (request: Request) => {
 		const filepath = path
 			.join(__resources, request.url.slice(`${PROTOCOL}://`.length))
 			.replace(/\/$/, ''); // remove trailing slash
+
+		// Prevent path traversal outside of resources directory
+		const resolved = path.resolve(filepath);
+		if (!resolved.startsWith(path.resolve(__resources))) {
+			Logger.warn(`Blocked path traversal attempt: ${request.url}`);
+			return new Response('Forbidden', { status: 403 });
+		}
+
 		const file = `file://${filepath}`;
 		Logger.info(`Protocol request: ${request.url}; File: ${file}`);
 		return net.fetch(file);

--- a/src/main/stopEvent.ts
+++ b/src/main/stopEvent.ts
@@ -1,10 +1,8 @@
 export const stopEvent = (event: Event) => {
 	if (typeof event.preventDefault === 'function') {
-		console.warn('Event prevented:', event);
 		event.preventDefault();
 	}
 	if (typeof event.stopPropagation === 'function') {
-		console.warn('Event stopped:', event);
 		event.stopPropagation();
 	}
 };

--- a/src/renderer/components/input/InputComboboxForm.tsx
+++ b/src/renderer/components/input/InputComboboxForm.tsx
@@ -71,7 +71,7 @@ export function InputComboboxForm({
 	function onSubmit(data: z.infer<typeof FormSchema>) {
 		onChange?.(data.itemValue);
 	}
-	console.log(items);
+
 	return (
 		<Form {...form}>
 			<form className="space-y-6">

--- a/src/renderer/context/global-context.tsx
+++ b/src/renderer/context/global-context.tsx
@@ -15,6 +15,7 @@ import {
 import { play, preload } from '@/renderer/lib/sounds';
 import { AppInfoType } from '@/types/app';
 import { CustomAcceleratorsType } from '@/types/keyboard';
+import { RendererNotificationOptions } from '@/types/notification';
 import { MenuItemConstructorOptions } from 'electron/renderer';
 import { toast } from 'sonner';
 
@@ -58,8 +59,6 @@ export function GlobalContextProvider({
 	useEffect(() => {
 		// Create handler for receiving asynchronous messages from the main process
 		const synchronizeAppState = async () => {
-			console.log(ipcChannels.APP_UPDATED);
-
 			window.electron.ipcRenderer
 				.invoke(ipcChannels.GET_RENDERER_SYNC)
 				.then((res) => {
@@ -73,29 +72,28 @@ export function GlobalContextProvider({
 		};
 
 		// Listen for messages from the main process
-		window.electron.ipcRenderer.on(ipcChannels.APP_UPDATED, async (data) => {
-			console.log('APP_UPDATED', data);
-
+		window.electron.ipcRenderer.on(ipcChannels.APP_UPDATED, async () => {
 			await synchronizeAppState();
 		});
 
 		// Create notifications using the renderer
 		window.electron.ipcRenderer.on(
 			ipcChannels.APP_NOTIFICATION,
-			({ title, body, action }: any) => {
+			(...args: unknown[]) => {
+				const { title, body, action } = args[0] as RendererNotificationOptions;
 				toast(title, {
 					...(body ? { description: body } : {}),
 					...(action ? { action } : {}),
-					// action: {
-					// 	label: 'Ok',
-					// 	onClick: () => {},
-					// },
 				});
+			},
+		);
 
-				// Renderer Web Notifications
-				// new Notification(title, {
-				// 	body,
-				// });
+		// Setup listener to play sounds
+		window.electron.ipcRenderer.on(
+			ipcChannels.PLAY_SOUND,
+			(...args: unknown[]) => {
+				if (!settings.allowSounds) return;
+				play({ name: args[0] as string });
 			},
 		);
 
@@ -104,17 +102,7 @@ export function GlobalContextProvider({
 			.invoke(ipcChannels.GET_APP_INFO)
 			.then((info) => {
 				setAppInfo(info);
-				return info;
-			})
-			.then(() => {
-				// SOUNDS
 				preload();
-
-				// Setup listener to play sounds
-				window.electron.ipcRenderer.on(ipcChannels.PLAY_SOUND, (sound: any) => {
-					if (!settings.allowSounds) return;
-					play({ name: sound });
-				});
 			})
 			.catch(console.error);
 

--- a/src/renderer/lib/color-picker/ColorPickerInput.tsx
+++ b/src/renderer/lib/color-picker/ColorPickerInput.tsx
@@ -21,7 +21,7 @@ export function ColorPickerInput({
 			<ColorPicker
 				initialValue={value}
 				colorSpace="hex"
-				onChange={console.log}
+				onChange={handleChange}
 				eyedropper
 			/>
 		</>

--- a/src/renderer/lib/sounds.ts
+++ b/src/renderer/lib/sounds.ts
@@ -39,13 +39,10 @@ const sounds: Record<string, { url: string; volume: number }> = {
 };
 
 export const preload = (basepath = '') => {
-	console.warn(`Preloading sounds`);
-
 	Object.keys(sounds).forEach((name) => {
 		if (!cache[name]) {
 			const sound = sounds[name];
 			const url = `${PROTOCOL}://${basepath}${sound.url}`;
-			console.warn(`Preloading sound: ${name}, URL: ${url}`);
 
 			cache[name] = new window.Audio();
 			cache[name].crossOrigin = '*';
@@ -57,7 +54,6 @@ export const preload = (basepath = '') => {
 
 export const play = ({ name, path }: { name: string; path?: string }) => {
 	const sound = name.toUpperCase();
-	console.info(`Playing sound: ${name}, path: ${path}`);
 
 	let audio: HTMLAudioElement | undefined = cache[sound];
 	if (!audio) {

--- a/src/utils/stopEvent.ts
+++ b/src/utils/stopEvent.ts
@@ -1,10 +1,8 @@
 export const stopEvent = (event: Event) => {
 	if (typeof event.preventDefault === 'function') {
-		console.warn('Event prevented:', event);
 		event.preventDefault();
 	}
 	if (typeof event.stopPropagation === 'function') {
-		console.warn('Event stopped:', event);
 		event.stopPropagation();
 	}
 };


### PR DESCRIPTION
## Summary

Backport of fixes from the downstream Cinematic audit pass. All bugs and nitpicks found in equivalent files have been applied here.

### Bugs fixed
- **`dialog.ts`**: Copyright overwrite bug — when both `options.copyright` and `options.text` were set, the second block overwrote instead of combining. Fixed with a single join.

### Security
- **`protocol.ts`**: Protocol handler had no path traversal guard — a crafted URL like \`app://../../etc/passwd\` could escape \`__resources\`. Added explicit \`path.resolve\` check and 403 response.

### Race condition
- **`global-context.tsx`**: \`PLAY_SOUND\` listener was registered inside a \`.then()\` callback, creating a window where unmounting before the promise resolved would leave the listener un-cleaned. Moved registration to synchronous setup code.

### Type safety
- **`dialog.ts`**: Replaced \`any\` on \`showAboutWindow\` options and \`aboutPanelOptions\` with proper types (\`AboutWindowOptions\` interface, \`Electron.AboutPanelOptionsOptions\`).
- **`protocol.ts`**: Replaced \`any\` on request param with \`Request\`.
- **`preload.ts`**: \`once()\` returned \`void\` while \`on()\` returned a cleanup function — inconsistent. Fixed \`once\` to also return \`(() => void) | undefined\`.
- **`global-context.tsx`**: Replaced \`any\` on notification and sound callbacks with proper types.
- **`menu.ts`**: Fixed inconsistent \`checked\` type cast on \`quitOnWindowClose\`.

### Debug logging
- Removed \`console.warn\` from both \`stopEvent.ts\` copies
- Removed \`console.warn\`/\`console.info\` from \`sounds.ts\`
- Removed \`console.log(items)\` from \`InputComboboxForm.tsx\`
- Removed debug \`console.log\` from \`global-context.tsx\`
- Fixed \`ColorPickerInput.tsx\` \`onChange={console.log}\` → \`onChange={handleChange}\`

## Test plan
- [ ] App starts
- [ ] Sounds play correctly
- [ ] Notifications display
- [ ] Color picker saves value
- [ ] Protocol handler serves assets (no path traversal)